### PR TITLE
Improved TXT-record handling, also handled an empty-cache case in Client.java

### DIFF
--- a/src/main/java/de/measite/minidns/Client.java
+++ b/src/main/java/de/measite/minidns/Client.java
@@ -178,7 +178,8 @@ public class Client {
         // findDNS()calls, which are expensive on Android. Note that we do not
         // put the results back into the Cache, as this is already done by
         // query(Question, String).
-        DNSMessage message = cache.get(q);
+        DNSMessage message = (cache == null) ? null : cache.get(q);
+
         if (message != null) {
             return message;
         }


### PR DESCRIPTION
I’m working on OpenKeychain which now uses minidns, and integrating with Keybase.io, which puts public-key "proofs" in DNS TXT records; so I used minidns to fetch the TXT records and I wanted to peek inside for a signed message.  Had to fix an unhandled cache miss in Client.java, but then it turns out TXT records are actually fussy.  There can be (but usually isn’t) more than one "extent" in a TXT record, each is a one-byte count followed by that many bytes of payload, which can be any binary gibberish (but are usually ASCII).  So I added a getExtents() method, and changed the getText() appropriately.  

This works fine for my purposes and I’ve run it over a bunch of different DNS entries.  It might be useful to argue over whether the API should return a List<String> rather than a List<byte[]>; the way I did it is more pedantically correct per RFC 1035; but less convenient, and in my code I just do a "new String()" on each extent anyhow.