### PR TITLE
Add Android API check and minor improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,11 @@ sourceCompatibility = 1.7
 version = 'dev'
 ext.isSnapshot = true
 
+ext {
+	minidnsMinAndroidSdk = 9
+	androidBootClasspath = getAndroidRuntimeJar()
+}
+
 if (!ext.isSnapshot && 'git rev-parse --abbrev-ref HEAD'.execute().text.trim() == 'master') {
   throw new org.gradle.api.InvalidUserDataException('Untagged version detected! Please tag every release.')
 }
@@ -84,4 +89,33 @@ modifyPom {
 
 dependencies {
     testCompile 'junit:junit:4.11'
+}
+
+task compileAndroid(type: JavaCompile) {
+	source = compileJava.source
+	classpath = compileJava.classpath
+	destinationDir = new File(buildDir, 'android')
+	options.bootClasspath = androidBootClasspath
+}
+
+test { dependsOn compileAndroid }
+
+def getAndroidRuntimeJar() {
+	def androidHome = getAndroidHome()
+	def androidJar = new File("$androidHome/platforms/android-$minidnsMinAndroidSdk/android.jar")
+	if (androidJar.isFile()) {
+		return androidJar
+	} else {
+		throw new Exception("Can't find android.jar for $minidnsMinAndroidSdk API. Please install corresponding SDK platform package")
+	}
+}
+
+def getAndroidHome() {
+	def androidHomeEnv = System.getenv("ANDROID_HOME")
+	if (androidHomeEnv == null) {
+		throw new Exception("ANDROID_HOME environment variable is not set")
+	}
+	def androidHome = new File(androidHomeEnv)
+	if (!androidHome.isDirectory()) throw new Exception("Environment variable ANDROID_HOME is not pointing to a directory")
+	return androidHome
 }

--- a/src/main/java/de/measite/minidns/Client.java
+++ b/src/main/java/de/measite/minidns/Client.java
@@ -185,10 +185,12 @@ public class Client {
      * @throws IOException On IOErrors.
      */
     public DNSMessage query(Question q, String host, int port) throws IOException {
+        // See if we have the answer to this question already cached
         DNSMessage dnsMessage = (cache == null) ? null : cache.get(q);
         if (dnsMessage != null) {
             return dnsMessage;
         }
+
         DNSMessage message = new DNSMessage();
         message.setQuestions(new Question[]{q});
         message.setRecursionDesired(true);
@@ -229,10 +231,10 @@ public class Client {
         // put the results back into the Cache, as this is already done by
         // query(Question, String).
         DNSMessage message = (cache == null) ? null : cache.get(q);
-
         if (message != null) {
             return message;
         }
+
         String dnsServer[] = findDNS();
         for (String dns : dnsServer) {
             try {

--- a/src/main/java/de/measite/minidns/Client.java
+++ b/src/main/java/de/measite/minidns/Client.java
@@ -58,6 +58,10 @@ public class Client {
         this.cache = cache;
     }
 
+    /**
+     * Creates a new client that uses the given Map as cache.
+     * @param cache
+     */
     public Client(final Map<Question, DNSMessage> cache) {
         this();
         if (cache != null)

--- a/src/main/java/de/measite/minidns/Client.java
+++ b/src/main/java/de/measite/minidns/Client.java
@@ -32,7 +32,7 @@ public class Client {
     /**
      * The internal random class for sequence generation.
      */
-    protected Random random;
+    protected final Random random;
 
     /**
      * The buffer size for dns replies.
@@ -54,20 +54,12 @@ public class Client {
      * @param cache The backend DNS cache.
      */
     public Client(DNSCache cache) {
-        try {
-            random = SecureRandom.getInstance("SHA1PRNG");
-        } catch (NoSuchAlgorithmException e1) {
-            random = new SecureRandom();
-        }
+        this();
         this.cache = cache;
     }
 
     public Client(final Map<Question, DNSMessage> cache) {
-        try {
-            random = SecureRandom.getInstance("SHA1PRNG");
-        } catch (NoSuchAlgorithmException e1) {
-            random = new SecureRandom();
-        }
+        this();
         if (cache != null)
             this.cache = new DNSCache() {
                 public void put(Question q, DNSMessage message) { cache.put(q, message); }
@@ -79,7 +71,13 @@ public class Client {
      * Create a new DNS client without any caching.
      */
     public Client() {
-        this((DNSCache)null);
+        Random random;
+        try {
+            random = SecureRandom.getInstance("SHA1PRNG");
+        } catch (NoSuchAlgorithmException e1) {
+            random = new SecureRandom();
+        }
+        this.random = random;
     }
 
     /**

--- a/src/main/java/de/measite/minidns/Client.java
+++ b/src/main/java/de/measite/minidns/Client.java
@@ -196,7 +196,12 @@ public class Client {
         message.setRecursionDesired(true);
         message.setId(random.nextInt());
         byte[] buf = message.toArray();
-        try (DatagramSocket socket = new DatagramSocket()) {
+
+        // TOOD Use a try-with-resource statement here once miniDNS minimum
+        // required Android API level is >= 19
+        DatagramSocket socket = null;
+        try {
+            socket = new DatagramSocket();
             DatagramPacket packet = new DatagramPacket(buf, buf.length,
                     InetAddress.getByName(host), port);
             socket.setSoTimeout(timeout);
@@ -216,6 +221,10 @@ public class Client {
                 }
             }
             return dnsMessage;
+        } finally {
+            if (socket != null) {
+                socket.close();
+            }
         }
     }
 

--- a/src/main/java/de/measite/minidns/util/NameUtil.java
+++ b/src/main/java/de/measite/minidns/util/NameUtil.java
@@ -2,7 +2,6 @@ package de.measite.minidns.util;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.net.IDN;
 import java.util.HashSet;
@@ -36,29 +35,22 @@ public class NameUtil {
         if (name2 == null) return false;
         if (name1.equals(name2)) return true;
 
-        try {
-            return Arrays.equals(toByteArray(name1),toByteArray(name2));
-        } catch (IOException e) {
-            return false; // impossible
-        }
+        return Arrays.equals(toByteArray(name1),toByteArray(name2));
     }
 
     /**
      * Serialize a domain name under IDN rules.
      * @param name The domain name.
      * @return The binary domain name representation.
-     * @throws IOException Should never happen.
      */
-    public static byte[] toByteArray(String name) throws IOException {
+    public static byte[] toByteArray(String name) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream(64);
-        DataOutputStream dos = new DataOutputStream(baos);
         for (String s: name.split("[.\u3002\uFF0E\uFF61]")) {
             byte[] buffer = IDN.toASCII(s).getBytes();
-            dos.writeByte(buffer.length);
-            dos.write(buffer);
+            baos.write(buffer.length);
+            baos.write(buffer, 0, buffer.length);
         }
-        dos.writeByte(0);
-        dos.flush();
+        baos.write(0);
         return baos.toByteArray();
     }
 


### PR DESCRIPTION
Turns out, miniDNS already uses some Android APIs that are not available on all Android versions.

What worries me a bit is the usage of the try-with-resource statement. I'm not even sure if ever worked on API < 19, but even if we suppose it didn't throw, I could imagine that the resource was never closed and we leaked a DatagramSocket.

With this test in place, we can easily guarantee a min Android API compatibility. Next st(o|e)p, travis-ci checks :)