### PR TITLE
Use Android SDK 9 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: android
 android:
   components:
-    - android-8
+    - android-9
 install: gradle assemble
 script: gradle check


### PR DESCRIPTION
This way Travis CI passes: https://travis-ci.org/rtreffer/minidns/builds/55687719