### PR TITLE
NPE fix

### DIFF
--- a/minidns-core/src/main/java/de/measite/minidns/DNSClient.java
+++ b/minidns-core/src/main/java/de/measite/minidns/DNSClient.java
@@ -113,13 +113,15 @@ public class DNSClient extends AbstractDNSClient {
         }
 
         List<InetAddress> dnsServerAddresses = new ArrayList<>(dnsServerCount + 2);
-        for (String dnsServerString : dnsServerStrings) {
-            if (dnsServerString == null || dnsServerString.isEmpty()) {
-                LOGGER.finest("findDns() returned null or empty string as dns server");
-                continue;
+        if (dnsServerStrings != null) {
+            for (String dnsServerString : dnsServerStrings) {
+                if (dnsServerString == null || dnsServerString.isEmpty()) {
+                    LOGGER.finest("findDns() returned null or empty string as dns server");
+                    continue;
+                }
+                InetAddress dnsServerAddress = InetAddress.getByName(dnsServerString);
+                dnsServerAddresses.add(dnsServerAddress);
             }
-            InetAddress dnsServerAddress = InetAddress.getByName(dnsServerString);
-            dnsServerAddresses.add(dnsServerAddress);
         }
 
         InetAddress[] selectedHardcodedDnsServerAddresses = new InetAddress[2];


### PR DESCRIPTION
Relating to issue https://github.com/rtreffer/minidns/issues/54 (which has already been solved in 0.2.2), NPE still occurs due to the same reason but in another line. This commit proposes a null check for the new NPE.